### PR TITLE
Setup storage logic using tauri-store plucgin, fix right section and …

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-store": "^2.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.2
+      '@tauri-apps/plugin-store':
+        specifier: ^2.4.1
+        version: 2.4.1
       react:
         specifier: ^19.1.0
         version: 19.2.3
@@ -582,6 +585,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.2':
     resolution: {integrity: sha512-ei/yRRoCklWHImwpCcDK3VhNXx+QXM9793aQ64YxpqVF0BDuuIlXhZgiAkc15wnPVav+IbkYhmDJIv5R326Mew==}
+
+  '@tauri-apps/plugin-store@2.4.1':
+    resolution: {integrity: sha512-ckGSEzZ5Ii4Hf2D5x25Oqnm2Zf9MfDWAzR+volY0z/OOBz6aucPKEY0F649JvQ0Vupku6UJo7ugpGRDOFOunkA==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1286,6 +1292,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.9.6
 
   '@tauri-apps/plugin-opener@2.5.2':
+    dependencies:
+      '@tauri-apps/api': 2.9.1
+
+  '@tauri-apps/plugin-store@2.4.1':
     dependencies:
       '@tauri-apps/api': 2.9.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1786,6 +1786,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-store",
 ]
 
 [[package]]
@@ -3647,6 +3648,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-store"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a77036340a97eb5bbe1b3209c31e5f27f75e6f92a52fd9dd4b211ef08bf310"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,7 +3880,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "just-cal"
 version = "0.1.0"
 description = "A Tauri App"
-authors = ["you"]
+authors = ["Rahul Rathaur"]
 edition = "2021"
 
 
@@ -24,4 +24,5 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
+tauri-plugin-store = "2.4.1"
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,0 +1,38 @@
+
+use serde::{Serialize, Deserialize};
+use chrono::{NaiveDate, NaiveDateTime};
+use std::default::Default;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+enum ItemState {
+    Draft = 0,
+    #[default]
+    Pending = 1,
+    Done = 2,
+    Discarted = 3,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct Item {
+    id: u32,
+    pub user_input: String,
+    title: String,
+    description: String,
+    status: ItemState,
+    time: NaiveDateTime,
+    reminder: Option<NaiveDateTime>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Day {
+    id: NaiveDate,
+    day: String,
+    month: u32,
+    year: u32,
+    items: Vec<Item>,
+}
+
+// match datetime {
+//     Some(dt) => println!("The datetime is: {}", dt),
+//     None => println!("The timestamp was invalid"),
+// }

--- a/src-tauri/src/storage_repo.rs
+++ b/src-tauri/src/storage_repo.rs
@@ -1,0 +1,160 @@
+use tauri::{AppHandle, EventLoopMessage, Runtime, State, Manager, Wry};
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, Utc, Weekday};
+use tauri_plugin_store::{Store, StoreBuilder, StoreExt};
+use std::sync::Mutex;
+use serde::{Serialize, Deserialize};
+use crate::{models::{Day, Item}, store::StoreManager};
+
+const STORE_FILE: &str = "db_justcal.json";
+const USERS_KEY: &str = "users";
+
+// async fn get_current_store<R: Runtime>(app: &AppHandle<Wry>) -> Result<Store<R>, String> {
+//     let mut store = StoreBuilder::new(app, STORE_FILE)
+//         .build()
+//         .map_err(|e| e.to_string())?;
+
+//     // Load existing data or create empty
+//     store.reload().map_err(|e| e.to_string())?;
+//     //store.save().map_err(|e| e.to_string())?;
+//     Ok(store)
+// }
+// async fn get_month_store(app: &AppHandle<Wry>, date: &str) -> Result<Store<Wry>, String> {
+//     let filename = get_store_filename(date);
+//     let mut store = StoreBuilder::new(app, &filename)
+//         .build()
+//         .map_err(|e| e.to_string())?;
+
+//     store.reload().map_err(|e| e.to_string())?; // creates if not exists
+//     Ok(store)
+// }
+// fn get_store(state: tauri::State<'_, Mutex<AppState>>) -> u32 {
+//     // Lock the mutex to get immutable access
+//     let state = app.state::<Mutex<>>();
+//     let app_state = state.lock().unwrap();
+//     app_state.counter
+// }
+
+fn convert_date_to_key(date: String) -> String {
+    // Date format is YYYY-MM-DDTHH:MM:SSZ when passed from frontend
+    let date_part = &date[0..10]; 
+    //YYYY-MM-DD
+    date_part.to_string()
+}
+fn convert_date_to_month_key(date: String) -> String {
+    // Date format is YYYY-MM-DDTHH:MM:SSZ when passed from frontend
+    let year = &date[0..4];
+    let month = &date[5..7];
+    //YYYY-MM
+    format!("{}-{}", year, month)
+}
+
+// #[derive(Serialize, Deserialize, Clone, Debug)]
+// pub struct StorageService{
+//     data: Vec<String>
+// }
+
+// Get for one date
+#[tauri::command]
+pub async fn get_items_for_date(app: AppHandle<Wry>, date: String) -> Result<Vec<Item>, String> {
+    //get the store for the month from App state
+    // let store = get_store(&app).await?;
+    // let key = format!("{}{}", KEY_PREFIX, date);
+    let store_manager = app.state::<StoreManager<Wry>>();
+    let date_key = convert_date_to_key(date.clone());
+    let month_key = convert_date_to_month_key(date.clone());
+
+    let stores = store_manager.stores.read().unwrap();
+
+    let store = stores
+    .get(&month_key)
+    .ok_or(format!("Store not found for month: {}", &month_key))?;
+
+    // if let Some(store) = stores.get(&month_key) {  // "MM-YYYY" format
+    // // Use the store
+    //     let items = store.get(date_key);
+    // } else {
+    //     // Store not found for that month
+    //     println!("Store not found");
+    // }
+    let obj_items = store
+        .get(&date_key)
+        .and_then(|v: serde_json::Value| serde_json::from_value::<Vec<Item>>(v.clone()).ok())
+        .unwrap_or_default();
+    
+    Ok(obj_items)
+}
+
+#[tauri::command]
+pub async fn get_items_for_month(manager: State<'_, StoreManager<Wry>>, date: String) -> Result<Vec<String>, String> {
+    //let key = convert_date_to_key(date);
+    let store_key = convert_date_to_month_key(date);
+    //let manager = app.state::<store::StoreManager<R>>();
+    let stores = manager.stores.read().unwrap();
+
+    let store = stores
+        .get(&store_key)
+        .ok_or("Store not found")?;
+    //get all items for the month, no filtering required here, all items stored in current store are for month
+    // let items = store
+    //     .get(&key)
+    //     .and_then(|v| serde_json::from_value(v.clone()).ok())
+    //     .into_iter()  
+    //     .map(|f: Item| f.user_input.clone())
+    //     .collect();
+    let month_items: Vec<String> = store
+        .keys()
+        .into_iter()
+        .filter_map(|k| store.get(&k))
+        .filter_map(|v: serde_json::Value| serde_json::from_value(v.clone()).ok())
+        //.and_then(|v| serde_json::from_value(v.clone()).ok())
+        //.into_iter()
+        .map(|f: Item| f.user_input.clone())
+        //.map(|k| k.strip_prefix(KEY_PREFIX).unwrap().to_string())
+        .collect();
+
+    Ok(month_items)
+}
+
+// Save/Update one date
+#[tauri::command]
+pub async fn save_items_for_date(manager: State<'_, StoreManager<Wry>>, date: String, items: Vec<Item>) -> Result<(), String> {
+    let key = convert_date_to_key(date.clone());
+    let store_key = convert_date_to_month_key(date.clone());
+
+    let stores = manager.stores.write().unwrap();
+    let store = stores
+        .get(&store_key)
+        .ok_or("Store not found")?;
+    store.set(key, serde_json::to_value(&items).map_err(|e| e.to_string())?);
+    store.save().map_err(|e| e.to_string())?;
+    store.reload().map_err(|e| e.to_string())?;
+    
+    Ok(())
+}
+
+// Optional: Delete one date
+#[tauri::command]
+pub async fn delete_items_for_date(manager: State<'_, StoreManager<Wry>>, date: String) -> Result<(), String> {
+    let key = convert_date_to_key(date.clone());
+    let store_key = convert_date_to_month_key(date.clone());
+    let stores = manager.stores.write().unwrap();
+    let store = stores
+        .get(&store_key)
+        .ok_or("Store not found")?;
+    store.delete(key);
+    store.save();
+    Ok(())
+}
+
+// Optional: Get list of all dates that have data
+// #[tauri::command]
+// pub async fn get_all_dates(app: AppHandle) -> Result<Vec<String>, String> {
+//     let store = get_store(&app).await?;
+//     let keys: Vec<String> = store
+//         .keys()
+//         .into_iter()
+//         .filter(|k| k.starts_with(KEY_PREFIX))
+//         .map(|k| k.strip_prefix(KEY_PREFIX).unwrap().to_string())
+//         .collect();
+//     Ok(keys)
+// }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -1,0 +1,124 @@
+use tauri::{State, Manager, Runtime};
+use tauri_plugin_store::{Store, StoreBuilder};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc, Local};
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::collections::HashMap;
+
+pub const DATE_FORMAT: &str = "%Y-%m-%d";
+
+pub struct StoreManager<R: Runtime> {
+    pub stores: RwLock<HashMap<String, Arc<Store<R>>>>,
+}
+
+fn date_to_month_key(date: String) -> String {
+    // Date format is YYYY-MM-DDTHH:MM:SSZ when passed from frontend
+    let year = &date[0..4];
+    let month = &date[5..7];
+    format!("{}-{}", year, month)
+}
+
+pub fn date_to_store_filename(date: &str) -> String {
+    // date is expected in "YYYY-MM-DD" format
+     let selected_date = if date.is_empty() {
+        let now_local: DateTime<Local> = Local::now();
+        now_local.format(DATE_FORMAT).to_string()
+    } else {
+        date.to_string()
+    };
+    let parts: Vec<&str> = selected_date.split('-').take(2).collect();
+    if parts.len() == 2 {
+        format!("{}-{}.json", parts[1], parts[0]) //MM-YYYY.json
+    } else {
+        "current.json".to_string() // fallback
+    }
+}
+
+//Store helper functions, create newm load from disk, save to disk, add to appstate etc.
+pub fn reload_store_from_disk<R: Runtime>(app: &tauri::AppHandle<R>, date: String) -> Result<Arc<Store<R>>, String> {
+    let filename = date_to_store_filename(&date);
+    let data_dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    let file_path = data_dir.join(&filename);
+    
+    let store = StoreBuilder::new(app, file_path)
+        .build()
+        .map_err(|e| e.to_string())?;
+    
+    store.reload().map_err(|e| e.to_string())?;
+    
+    // Update or add store to app state via StoreManager
+    add_store_to_app_state(app, &date, Some(store.clone()));
+    
+    Ok(store)
+}   
+
+pub fn setup_new_store<R: Runtime>(app: &tauri::AppHandle<R>, date: &str) ->  Result<Arc<Store<R>>, String> {
+    let filename = date_to_store_filename(date);
+    //let data_dir = app_data_dir(&config).expect("failed to resolve app data dir");
+    let data_dir = app.path().app_data_dir().expect("failed to resolve app data dir");
+    let file_path = data_dir.join(filename); // or similar
+    println!("Store setup started with file: {}", file_path.display());
+    let store = StoreBuilder::new(app, file_path)
+        .build()
+        .map_err(|e| e.to_string())?;
+    
+    store.save().map_err(|e| e.to_string())?;
+    
+    // Add store to app state via StoreManager
+    add_store_to_app_state(app, date, Some(store.clone()));
+    
+    Ok(store)
+}
+
+pub fn initialize_store_manager<R: Runtime>() -> StoreManager<R> {
+    StoreManager {
+        stores: RwLock::new(HashMap::new()),
+    }
+}
+
+pub fn get_store_manager<R: Runtime>(app: &tauri::AppHandle<R>) -> State<'_, StoreManager<R>> {
+    return app.state::<StoreManager<R>>().clone();
+}
+
+pub fn get_store_from_app_state<R: Runtime>(app: &tauri::AppHandle<R>, date: &str) -> Result<Arc<Store<R>>, String> {
+    let store_manager = get_store_manager(app);
+    let month_key = date_to_store_filename(date).split('.').next().unwrap_or("current").to_string();
+    let stores_lock = store_manager.stores.read().unwrap();
+    if let Some(store) = stores_lock.get(&month_key) {
+        Ok(store.clone())
+    } else {
+        Err("Store for the month not found".to_string())
+    }
+}
+
+pub fn add_store_to_app_state<R: Runtime>(app: &tauri::AppHandle<R>, date: &str, store: Option<Arc<Store<R>>>) {
+    
+    let this_month_store = if store.is_none() { 
+        reload_store_from_disk(&app, date.to_string()) 
+    } else { 
+        Ok(store.unwrap()) 
+    };
+    match this_month_store {
+        Ok(store) => {
+            let store_manager = app.state::<StoreManager<R>>();
+            let mut store_manager_lock = store_manager.stores.write().unwrap();
+            let month_key = date_to_store_filename(&date).split('.').next().unwrap_or("current").to_string();
+            store_manager_lock.insert(month_key.to_string(), store);
+            println!("Store updated for month key: {}", month_key);
+        },
+        Err(e) => {
+            println!("Error updating store: {}, {}", &date, e);
+        }
+    }
+    
+}
+
+pub fn get_current_store<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<Arc<Store<R>>, String> {
+    let store_manager = get_store_manager(app);
+    let stores_lock = store_manager.stores.read().unwrap();
+    if let Some(store) = stores_lock.get("current") {
+        Ok(store.clone())
+    } else {
+        Err("Current store not found".to_string())
+    }
+}

--- a/src/NewApp.jsx
+++ b/src/NewApp.jsx
@@ -1,8 +1,8 @@
 import SettingsIcon from './components/icons/setting'
-import BarsIcon from './components/icons/bars';
-import ThemeLightIcon from './components/icons/themeLight';
-import ThemeDarkIcon from './components/icons/themeDark';
-import Day from './components/Day';
+import BarsIcon from './components/icons/Bars';
+import ThemeLightIcon from './components/icons/ThemeLight';
+import ThemeDarkIcon from './components/icons/ThemeDark';
+import Day from './components/day';
 import JustDate from './utilities/justDate';
 import { useMemo, useState, useRef } from 'react';
 import { useTheme } from './hooks/useTheme';

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -114,5 +114,5 @@
   background-size: contain;
 }
 [contenteditable]:focus {
-  outline: 1px solid rgb(121, 121, 157);
+  outline: 1px solid #422ad5;
 }

--- a/src/components/Day.jsx
+++ b/src/components/Day.jsx
@@ -32,6 +32,7 @@ export default function Day(props) {
     async function fetchDayItems() {
       try {
         if (date) {
+          console.log('in day: ', date);
           const dayItems = await invoke("fetch_day_items", { date });
           //console.log("Fetched day items:", dayItems);
           setTasks(dayItems);
@@ -48,8 +49,8 @@ export default function Day(props) {
     console.log(event);
     let h2 = event && event.target;//.children
     console.log(h2.tagName);
-    if (h2 && h2.tagName === 'H2') {
-      alert(date + ' ' + h2.innerText);
+    if (h2 && h2.tagName === 'H2' || h2.tagName === "DIV") {
+      props.handleSelectedDate(date.getDate());
     }
   };
 
@@ -204,6 +205,7 @@ export default function Day(props) {
     if (ul && ul.children.length === 0) {
       addFirstLiAndFocus(ul);
     }
+    handleDayClick(e);
   };
 
   const handleBlur = (e) => {
@@ -224,11 +226,14 @@ export default function Day(props) {
 
   return (
     <div key={index}
-      className={"p-0 h-42 flex flex-col " + (date && date.getDate() === selectedDate ? " " : "")}
+      className={"p-0 h-42 flex flex-col " 
+        + (date && date.getDate() === selectedDate ? "border-2 border-info/80" : "") 
+        + (index >= 28 ? "border-r border-base-content/20": "")}//this is to avoid right border
+        //  missing in last div, 28 index tells the last line has items.
     >
       {date && (<>
         <a className={"link inline-block p-0 bg-base-200 rounded hover:text-accent hover:bg-base-300 " + (date && date.getDayName() === "Sunday" ? 'link-secondary' : '')}>
-          <h2 className={"text-2xl pt-1 pr-2 font-bold flex justify-end " + (date && date.getDate() === selectedDate ? "text-info-content bg-info" : "")}
+          <h2 className={"text-xl pt-1 pr-2 font-bold flex justify-end " + (date && date.getDate() === selectedDate ? "text-info-content/90 bg-info/80 hover:text-info-content hover:bg-info " : "")}
             onClick={handleDayClick}>{date.getDate()}</h2></a>
         {/* <div className="card bg-base-100">*/}
         <div id={"editable-div-" + index} key={index} className="overflow-y-auto min-h-10 max-h-30 no-scrollbar p-0 text-xxs focus:outline-1 custom-editor"
@@ -241,7 +246,7 @@ export default function Day(props) {
           onFocus={handleFocus}
           onBlur={handleBlur}
         >
-          <ul className="mt-2 flex flex-col p-1 gap-1 text-sm leading-none text-base-content">
+          <ul className="mt-1 flex flex-col p-1 gap-1 text-sm leading-none text-base-content">
             {tasks && tasks.length > 0 && tasks.map((task, index) => (
               <li key={index}>
                 {/* <CheckIcon className="w-4 h-4" /> */}

--- a/src/components/Month.jsx
+++ b/src/components/Month.jsx
@@ -4,6 +4,8 @@ import { useMemo, useState, useRef } from 'react';
 import { useTheme } from './../hooks/useTheme';
 import { event } from '@tauri-apps/api';
 import useWindowWidth from './../hooks/useWindowWidth';
+import RightSection from './RightSection';
+
 
 function Month(props) {
   const [monthDays, setMonthDays] = useState([]);
@@ -16,22 +18,31 @@ function Month(props) {
   const month = JustDate.getMonthIndex(props.month);
   const year = props.year;
   //setSelectedDate(props.date);
-  
+
+  const handleSelectedDate = (date)=> {
+      console.log(date);
+    if(Number.isInteger(date)){
+      setSelectedDate(date);
+    } else{
+      console.error('Not a valid date selected.');
+    }
+  };
+
   const monthDates = useMemo(() => {
     //if we have month and year defined, initlize the date using them. Else take current date.
-    let currentViewDate = (month > -1) && year ? new Date(year, month, selectedDate): new Date();
+    let currentViewDate = (month > -1) && year ? new Date(year, month, selectedDate) : new Date();
 
     const justDate = new JustDate(currentViewDate, 'en-US');
     const monthDates = justDate.getMonthDates();
     const monthDays = justDate.getDayNumbersInMonth();
-    const dayNameFormat = width > 700 ? 'long': width > 300 ? 'short': 'narrow';
+    const dayNameFormat = width > 700 ? 'long' : width > 300 ? 'short' : 'narrow';
     const weekDays = justDate.getLocalizedWeekdays(dayNameFormat);
     const localeMonth = justDate.getMonthName();
 
     let weekInfo = justDate.getLocaleWeekInfo();//This gives firstDay 1 based, Monday is 1, ..
     const firstDay = weekInfo.firstDay % 7; //To convert into 0 based. Monday is 1, Sunday is 0;
     let firstDayOfMonth = monthDates[0].getDay();
-    
+
     let monthStartOffset = firstDayOfMonth - firstDay;
     setMonthStart(monthStartOffset);
     let emptyDates = Array.from({ length: monthStartOffset }, (v, i) => undefined);
@@ -48,60 +59,29 @@ function Month(props) {
 
 
   return (
-    // <div className="h-screen flex flex-col bg-header-base1">
-      <div className="h-[calc(100vh-3rem)] flex flex-1 overflow-hidden">
-        {/* 2. Bottom Left Section - 80% width */}
-        <div className="w-full lg:w-4/5 bg-base-100 flex flex-col">
-          {/* Optional: Inner header or toolbar */}
-          <div className="bg-base-200 p-2 border-b border-base-100 text-base-content">
-            <div className="grid grid-cols-7 flex-row ">
-              {weekDays.map((day) => (
-                <div key={monthName+day} className="pl-0 p-2 h-8 text-xl text-left font-semibold">{day}</div>
+    <div className="h-[calc(100vh-3rem)] flex flex-1 overflow-hidden">
+      {/* 2. Bottom Left Section - 80% width */}
+      <div className="w-full lg:w-4/5 bg-base-100 flex flex-col">
+        {/* Optional: Inner header or toolbar */}
+        <div className="pl-3 bg-base-100/90 p-2 border-b border-base-100 text-base-content">
+          <div className="grid grid-cols-7 flex-row ">
+            {weekDays.map((day) => (
+              <div key={monthName + day} className="pl-0 p-2 h-8 text-xl text-left font-semibold">{day}</div>
+            ))}
+          </div>
+        </div>
+        <div className="flex-1 p-2 pt-0 overflow-y-auto">
+          <div className="prose max-w-none">
+            <div className="grid grid-cols-7 divide-x divide-y divide-base-content/20 text-base-content border border-base-content/20">
+              {monthDates.map((date, idx) => (
+                <Day key={idx} date={date} index={idx} selectedDate={selectedDate} handleSelectedDate={handleSelectedDate} />
               ))}
             </div>
           </div>
-
-          {/* Main scrollable content */}
-          <div className="flex-1 p-2 pt-0 overflow-y-auto">
-            <div className="prose max-w-none">
-
-              <div className="grid grid-cols-7 divide-x divide-y divide-base-content/20 text-base-content border border-base-content/20">
-                {monthDates.map((date, idx) => (
-                   <Day key={idx} date={date} index={idx} selectedDate={selectedDate} />
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* 3. Right Sidebar - 20% width */}
-        <div className="hidden lg:block w-1/5 bg-base-200 border-l border-base-200 text-base-content">
-          <div className="p-4 border-b border-base-200">
-            <h3 className="font-semibold text-base-content">Sidebar</h3>
-            <p className="text-md text-header-base-content/70">20% width panel</p>
-          </div>
-
-          <div className="p-4 space-y-4 overflow-y-auto h-full">
-            <div className="card bg-base-100 shadow-sm">
-              <div className="card-body p-4">
-                <h4 className="card-title text-md">Item 1</h4>
-                <p className="text-sm">Details...</p>
-                <input type="text" 
-                className="input input-primary text-md input-sm w-full max-w-xs bg-base-100 focus:outline-none focus:border-primary/70 focus:border-2"
-                placeholder="Add new item this day.."></input>
-              </div>
-            </div>
-            <div className="card bg-base-100 shadow-sm">
-              <div className="card-body p-4">
-                <h4 className="card-title text-sm">Item 2</h4>
-                <p className="text-xs">More info...</p>
-              </div>
-            </div>
-            {/* Add more sidebar items as needed */}
-          </div>
         </div>
       </div>
-    // </div>
+      <RightSection month={month} monthName={monthName} year={year} selectedDate={selectedDate} />
+    </div >
   )
 }
 

--- a/src/components/RightSection.jsx
+++ b/src/components/RightSection.jsx
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react';
+import { invoke } from "@tauri-apps/api/core";
+
+function RightSection(props) {
+	const month = props.month;
+	const monthName = props.monthName;
+	const year = props.year;
+	let selectedDate = props.selectedDate;
+	console.log(selectedDate);
+	let dateObj = new Date(year, month, selectedDate);
+	console.log('obj: ', dateObj);
+	//const [currentDate, setCurrentDate] = useState(selectedDate);
+	const [date, setDate] = useState(dateObj);
+	const [items, setItems] = useState([]);
+
+	useEffect(() => {
+		async function fetchDayItems() {
+			try {
+				if (date) {
+					let date = new Date(year, month, selectedDate);
+				console.log('calling fetch_date_items.', date);
+					const dayItems = await invoke("fetch_day_items", { date });
+					console.log("Fetched day items:", dayItems);
+					setItems(dayItems);
+				}
+			} catch (error) {
+				console.error("Failed to fetch day items:", error);
+			}
+		}
+		fetchDayItems();
+	}, [date, selectedDate]);
+
+	return (
+		<div className="hidden lg:block w-1/5 bg-base-100/90 border-l border-base-200 text-base-content">
+			<div className="text-xl p-2 border-b border-base-100">
+				<h3 className="font-semibold text-base-content">{"Your day: " + monthName + " " + selectedDate + ", " + year}</h3>
+			</div>
+
+			<div className="p-2 space-y-4 overflow-y-auto h-full">
+				{items.map((item, index) => (
+					<div key={index} className="card bg-base-100 shadow-md">
+						<div className="card-body p-4">
+							<h4 className="card-title text-md">{item.item}</h4>
+							<p className="text-sm">{item.status}</p>
+						</div>
+					</div>
+				))}
+
+				<div className="card bg-base-100 shadow-sm">
+					<div className="card-body p-4">
+						<h4 className="card-title text-md">New Item:</h4>
+						<input type="text"
+							className="input input-primary text-md input-md w-full max-w-xs bg-base-100 focus:outline-none focus:border-primary/70 focus:border-2"
+							placeholder="Add new item for this day.."></input>
+					</div>
+				</div>
+				{/* Add more sidebar items as needed */}
+			</div>
+		</div>
+	)
+}
+
+export default RightSection;


### PR DESCRIPTION
Has multiple changes:
1. Use tauri:store plugin for storage of cal data.
2. Creating separate db file for each month.
3. Loading needed db into tauri's app state for easy access.
4. Creating APIs to save/get items of a date, get items of month etc.
5. Fixing right section in UI,  needs more improvements.
6. Day and extended day to be fixed. 